### PR TITLE
sdk: Add constant for new translations index file (TEDEFO-2707)

### DIFF
--- a/src/main/java/eu/europa/ted/eforms/sdk/SdkConstants.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/SdkConstants.java
@@ -56,6 +56,10 @@ public class SdkConstants {
      * Internationalisation, labels.
      */
     TRANSLATIONS(Path.of("translations")), //
+    /**
+     * The index file for translations, only present in SDK 1.10.0 and later.
+     */
+    TRANSLATIONS_JSON(Path.of("translations", "translations.json")), //
 
     VIEW_TEMPLATES(Path.of("view-templates")), //
     VIEW_TEMPLATES_JSON(Path.of("view-templates", "view-templates.json"));


### PR DESCRIPTION
This file was added in SDK 1.10.0, so put a comment to indicate this.