### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
     <!-- Versions - Third-party libraries -->
-    <version.antlr4>4.9.3</version.antlr4>
+    <version.antlr4>4.13.1</version.antlr4>
     <version.commons-collections>3.2.2</version.commons-collections>
     <version.commons-io>2.11.0</version.commons-io>
     <version.commons-lang3>3.12.0</version.commons-lang3>

--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,7 @@
     <version.jackson>2.15.1</version.jackson>
     <version.jaxb-impl>2.3.9</version.jaxb-impl>
     <version.jool>0.9.15</version.jool>
-    <version.jsr305>3.0.2</version.jsr305>
     <version.junit>5.7.2</version.junit>
-    <version.logback>1.4.14</version.logback>
     <version.maven>3.8.6</version.maven>
     <version.ph-jaxb>10.1.8</version.ph-jaxb>
     <version.ph-genericode>6.3.0</version.ph-genericode>
@@ -207,21 +205,6 @@
 
       <!-- Other -->
       <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>${version.logback}</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-        <version>${version.logback}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.code.findbugs</groupId>
-        <artifactId>jsr305</artifactId>
-        <version>${version.jsr305}</version>
-      </dependency>
-      <dependency>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-runtime</artifactId>
         <version>${version.antlr4}</version>
@@ -342,21 +325,6 @@
     </dependency>
 
     <!-- Other -->
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <version.javadoc.plugin>3.4.0</version.javadoc.plugin>
     <version.source.plugin>3.2.1</version.source.plugin>
     <version.jar.plugin>3.3.0</version.jar.plugin>
-    <version.surefire.plugin>3.0.0-M7</version.surefire.plugin> <!-- Versions prior to 3.0.x do not pick up Junit 5 tests correctly. -->
+    <version.surefire.plugin>3.2.5</version.surefire.plugin>
     <version.nexus-staging.plugin>1.6.7</version.nexus-staging.plugin>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,13 +60,14 @@
     <version.commons-io>2.11.0</version.commons-io>
     <version.commons-lang3>3.12.0</version.commons-lang3>
     <version.jackson>2.15.1</version.jackson>
+    <version.jaxb-impl>2.3.9</version.jaxb-impl>
     <version.jool>0.9.15</version.jool>
     <version.jsr305>3.0.2</version.jsr305>
     <version.junit>5.7.2</version.junit>
     <version.logback>1.4.14</version.logback>
     <version.maven>3.8.6</version.maven>
-    <version.ph>10.0.0</version.ph>
-    <version.ph-genericode>6.2.0</version.ph-genericode>
+    <version.ph-jaxb>10.1.8</version.ph-jaxb>
+    <version.ph-genericode>6.3.0</version.ph-genericode>
     <version.reflections>0.10.2</version.reflections>
     <version.resolver>1.8.2</version.resolver>
     <version.semver4j>3.1.0</version.semver4j>
@@ -180,9 +181,15 @@
 
       <!-- PH -->
       <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>${version.jaxb-impl}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
         <groupId>com.helger.commons</groupId>
-        <artifactId>ph-commons</artifactId>
-        <version>${version.ph}</version>
+        <artifactId>ph-jaxb</artifactId>
+        <version>${version.ph-jaxb}</version>
       </dependency>
       <dependency>
         <!-- For genericode .gc files (SDK codelist related) -->
@@ -321,8 +328,12 @@
 
     <!-- PH -->
     <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.helger.commons</groupId>
-      <artifactId>ph-commons</artifactId>
+      <artifactId>ph-jaxb</artifactId>
     </dependency>
     <dependency>
       <!-- For genericode .gc files (SDK codelist related) -->

--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,12 @@
     <version.commons-io>2.11.0</version.commons-io>
     <version.commons-lang3>3.12.0</version.commons-lang3>
     <version.jackson>2.15.1</version.jackson>
-    <version.jaxb-impl>2.3.9</version.jaxb-impl>
+    <version.jaxb-impl>4.0.4</version.jaxb-impl>
     <version.jool>0.9.15</version.jool>
     <version.junit>5.7.2</version.junit>
     <version.maven>3.8.6</version.maven>
-    <version.ph-jaxb>10.1.8</version.ph-jaxb>
-    <version.ph-genericode>6.3.0</version.ph-genericode>
+    <version.ph-jaxb>11.1.3</version.ph-jaxb>
+    <version.ph-genericode>7.1.1</version.ph-genericode>
     <version.reflections>0.10.2</version.reflections>
     <version.resolver>1.8.2</version.resolver>
     <version.semver4j>3.1.0</version.semver4j>


### PR DESCRIPTION
Update the versions of various dependencies (ph-genericode, JAXB, Antlr4), and cleanup some unused dependencies. See individual commits for details.

I will create a similar PR for efx-toolkit-java, as we should avoid mixing up various versions of the same dependency, as this can create problems.