### PR TITLE
Check API changes against SemVer rules during build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build and run unit tests
+on:
+  push:
+  pull_request:
+
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Build and run unit tests
+        run: mvn --batch-mode clean install

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
     <version.gpg.plugin>1.5</version.gpg.plugin>
     <version.install.plugin>2.5.2</version.install.plugin>
     <version.jacoco.plugin>0.8.10</version.jacoco.plugin>
+    <version.japicmp.plugin>0.20.0</version.japicmp.plugin>
     <version.javadoc.plugin>3.4.0</version.javadoc.plugin>
     <version.source.plugin>3.2.1</version.source.plugin>
     <version.jar.plugin>3.3.0</version.jar.plugin>
@@ -394,6 +395,11 @@
           <version>${version.jacoco.plugin}</version>
         </plugin>
         <plugin>
+          <groupId>com.github.siom79.japicmp</groupId>
+          <artifactId>japicmp-maven-plugin</artifactId>
+          <version>${version.japicmp.plugin}</version>
+        </plugin>
+        <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>nexus-staging-maven-plugin</artifactId>
           <version>${version.nexus-staging.plugin}</version>
@@ -453,6 +459,28 @@
             <phase>prepare-package</phase>
             <goals>
               <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+        <configuration>
+          <!-- Old and new versions are not specified, so we compare the latest released version with the build artefact -->
+          <parameter>
+            <!-- Break the build in case the semantic versioning is violated -->
+            <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
+            <!-- Output only modified classes/methods in the report -->
+            <onlyModified>true</onlyModified>
+          </parameter>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>cmp</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Use japicmp to detect any changes in the public API compared to the previous release, and fail the build if the rules of semantic versioning are violated.

This is run during the "verify" phase, just before the "install" phase. It also outputs the API differences in the target/japicmp folder.

Also add a workflow to build, run unit tests and the above check for every push and PR.