### PR TITLE
Add qualifier for SDK component, to allow differentiating components the same SDK version and component type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <version.jaxb-impl>4.0.4</version.jaxb-impl>
     <version.jool>0.9.15</version.jool>
     <version.junit>5.7.2</version.junit>
+    <version.logback>1.5.3</version.logback>
     <version.maven>3.8.6</version.maven>
     <version.ph-jaxb>11.1.3</version.ph-jaxb>
     <version.ph-genericode>7.1.1</version.ph-genericode>
@@ -206,6 +207,16 @@
 
       <!-- Other -->
       <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${version.logback}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${version.logback}</version>
+      </dependency>
+      <dependency>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-runtime</artifactId>
         <version>${version.antlr4}</version>
@@ -326,6 +337,16 @@
     </dependency>
 
     <!-- Other -->
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>

--- a/src/main/java/eu/europa/ted/eforms/sdk/component/SdkComponent.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/component/SdkComponent.java
@@ -13,4 +13,6 @@ public @interface SdkComponent {
   public String[] versions();
 
   public SdkComponentType componentType();
+
+  public String qualifier() default "";
 }

--- a/src/main/java/eu/europa/ted/eforms/sdk/component/SdkComponentDescriptor.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/component/SdkComponentDescriptor.java
@@ -23,12 +23,20 @@ public class SdkComponentDescriptor<T> implements Serializable {
 
   private SdkComponentType componentType;
 
+  private String qualifier;
+
   private Class<T> implType;
 
   public SdkComponentDescriptor(String sdkVersion, SdkComponentType componentType,
       Class<T> implType) {
+    this(sdkVersion, componentType, "", implType);
+  }
+
+  public SdkComponentDescriptor(String sdkVersion, SdkComponentType componentType, String qualifier,
+      Class<T> implType) {
     this.sdkVersion = Validate.notBlank(sdkVersion, "Undefined SDK version");
     this.componentType = Validate.notNull(componentType, "Undefined component type");
+    this.qualifier = Validate.notNull(qualifier, "Undefined qualifier");
     this.implType = Validate.notNull(implType, "Undefined implementation type");
   }
 
@@ -94,7 +102,7 @@ public class SdkComponentDescriptor<T> implements Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(sdkVersion, componentType, implType);
+    return Objects.hash(componentType, sdkVersion, qualifier, implType);
   }
 
   @Override
@@ -106,8 +114,9 @@ public class SdkComponentDescriptor<T> implements Serializable {
     if (getClass() != obj.getClass())
       return false;
     SdkComponentDescriptor<?> other = (SdkComponentDescriptor<?>) obj;
-    return componentType == other.componentType
+    return componentType == other.componentType 
         && Objects.equals(sdkVersion, other.sdkVersion)
+        && Objects.equals(qualifier, other.qualifier)
         && Objects.equals(implType, other.implType);
   }
 

--- a/src/main/java/eu/europa/ted/eforms/sdk/component/SdkComponentDescriptor.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/component/SdkComponentDescriptor.java
@@ -94,7 +94,7 @@ public class SdkComponentDescriptor<T> implements Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(componentType, sdkVersion);
+    return Objects.hash(sdkVersion, componentType, implType);
   }
 
   @Override
@@ -106,7 +106,9 @@ public class SdkComponentDescriptor<T> implements Serializable {
     if (getClass() != obj.getClass())
       return false;
     SdkComponentDescriptor<?> other = (SdkComponentDescriptor<?>) obj;
-    return componentType == other.componentType && Objects.equals(sdkVersion, other.sdkVersion);
+    return componentType == other.componentType
+        && Objects.equals(sdkVersion, other.sdkVersion)
+        && Objects.equals(implType, other.implType);
   }
 
   public Class<T> getImplType() {

--- a/src/main/java/eu/europa/ted/eforms/sdk/component/SdkComponentFactory.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/component/SdkComponentFactory.java
@@ -3,9 +3,9 @@ package eu.europa.ted.eforms.sdk.component;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.reflections.Reflections;
@@ -20,7 +20,40 @@ import org.slf4j.LoggerFactory;
 public abstract class SdkComponentFactory {
   private static final Logger logger = LoggerFactory.getLogger(SdkComponentFactory.class);
 
-  private Map<String, Map<SdkComponentType, SdkComponentDescriptor<?>>> componentsMap;
+  private Map<String, Map<ComponentSelector, SdkComponentDescriptor<?>>> componentsMap;
+
+  class ComponentSelector {
+    private final SdkComponentType componentType;
+    private final String qualifier;
+
+    public ComponentSelector(SdkComponentType componentType, String qualifier) {
+      this.componentType = componentType;
+      this.qualifier = qualifier;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(componentType, qualifier);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj)
+        return true;
+      if (obj == null)
+        return false;
+      if (getClass() != obj.getClass())
+        return false;
+      ComponentSelector other = (ComponentSelector) obj;
+      if (!getEnclosingInstance().equals(other.getEnclosingInstance()))
+        return false;
+      return componentType == other.componentType && Objects.equals(qualifier, other.qualifier);
+    }
+
+    private SdkComponentFactory getEnclosingInstance() {
+      return SdkComponentFactory.this;
+    }
+  }
 
   protected SdkComponentFactory() {
     populateComponents();
@@ -54,6 +87,8 @@ public abstract class SdkComponentFactory {
 
           String[] supportedSdkVersions = annotation.versions();
           SdkComponentType componentType = annotation.componentType();
+          String qualifier = annotation.qualifier();
+          ComponentSelector selector = new ComponentSelector(componentType, qualifier);
 
           logger.trace("Class [{}] has a component type of [{}] and supports SDK versions [{}]",
               clazz, componentType, supportedSdkVersions);
@@ -62,11 +97,11 @@ public abstract class SdkComponentFactory {
             SdkComponentDescriptor<?> component =
                 new SdkComponentDescriptor<>(sdkVersion, componentType, clazz);
 
-            Map<SdkComponentType, SdkComponentDescriptor<?>> components =
+            Map<ComponentSelector, SdkComponentDescriptor<?>> components =
                 componentsMap.get(sdkVersion);
 
             if (components != null) {
-              SdkComponentDescriptor<?> existingComponent = components.get(componentType);
+              SdkComponentDescriptor<?> existingComponent = components.get(selector);
 
               if (existingComponent != null && !existingComponent.equals(component)) {
                 throw new IllegalArgumentException(MessageFormat.format(
@@ -75,11 +110,11 @@ public abstract class SdkComponentFactory {
                     clazz.getName()));
               }
             } else {
-              components = new EnumMap<>(SdkComponentType.class);
+              components = new HashMap<>();
               componentsMap.put(sdkVersion, components);
             }
 
-            components.put(componentType, component);
+            components.put(selector, component);
           });
         });
   }
@@ -87,18 +122,27 @@ public abstract class SdkComponentFactory {
   protected <T> T getComponentImpl(String sdkVersion, final SdkComponentType componentType,
       final Class<T> intf, Object... initArgs) throws InstantiationException {
 
+    return getComponentImpl(sdkVersion, componentType, "", intf, initArgs);
+  }
+
+  protected <T> T getComponentImpl(String sdkVersion, final SdkComponentType componentType,
+      final String qualifier, final Class<T> intf, Object... initArgs) throws InstantiationException {
+
     String normalizedVersion = normalizeVersion(sdkVersion);
+
+    ComponentSelector selector = new ComponentSelector(componentType, qualifier);
 
     @SuppressWarnings("unchecked")
     SdkComponentDescriptor<T> descriptor =
         (SdkComponentDescriptor<T>) Optional.ofNullable(componentsMap.get(normalizedVersion))
-            .orElseGet(Collections::emptyMap).get(componentType);
+            .orElseGet(Collections::emptyMap).get(selector);
 
     if (descriptor == null) {
       logger.error("Failed to load required components of SDK [{}]", sdkVersion);
       throw new IllegalArgumentException(
-          MessageFormat.format("No implementation found for component type [{0}] of SDK [{1}].",
-              componentType, sdkVersion));
+          MessageFormat.format(
+              "No implementation found for SDK [{0}], component type [{1}] and qualifier '{2}'.",
+              sdkVersion, componentType, qualifier));
     }
 
     return descriptor.createInstance(initArgs);

--- a/src/test/java/eu/europa/ted/eforms/sdk/component/MyComponent.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/component/MyComponent.java
@@ -1,0 +1,10 @@
+package eu.europa.ted.eforms.sdk.component;
+
+@SdkComponent(versions = "0.5", componentType = SdkComponentType.EFX_EXPRESSION_TRANSLATOR)
+class MyComponent implements TestComponent {
+
+  @Override
+  public String testMethod() {
+    return null;
+  }
+}

--- a/src/test/java/eu/europa/ted/eforms/sdk/component/MyComponentFactory.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/component/MyComponentFactory.java
@@ -7,4 +7,10 @@ class MyComponentFactory extends SdkComponentFactory {
       Object... initArgs) throws InstantiationException {
     return super.getComponentImpl(sdkVersion, componentType, intf, initArgs);
   }
+
+  @Override
+  protected <T> T getComponentImpl(String sdkVersion, SdkComponentType componentType,
+      String qualifier, Class<T> intf, Object... initArgs) throws InstantiationException {
+    return super.getComponentImpl(sdkVersion, componentType, qualifier, intf, initArgs);
+  }
 }

--- a/src/test/java/eu/europa/ted/eforms/sdk/component/MyComponentFactory.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/component/MyComponentFactory.java
@@ -1,0 +1,10 @@
+package eu.europa.ted.eforms.sdk.component;
+
+class MyComponentFactory extends SdkComponentFactory {
+
+  @Override
+  protected <T> T getComponentImpl(String sdkVersion, SdkComponentType componentType, Class<T> intf,
+      Object... initArgs) throws InstantiationException {
+    return super.getComponentImpl(sdkVersion, componentType, intf, initArgs);
+  }
+}

--- a/src/test/java/eu/europa/ted/eforms/sdk/component/NodeComponentWithQualifier.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/component/NodeComponentWithQualifier.java
@@ -1,0 +1,10 @@
+package eu.europa.ted.eforms.sdk.component;
+
+@SdkComponent(versions = "1", componentType = SdkComponentType.NODE, qualifier = "qualifier")
+public class NodeComponentWithQualifier implements TestComponent {
+
+  @Override
+  public String testMethod() {
+    return "Node";
+  }
+}

--- a/src/test/java/eu/europa/ted/eforms/sdk/component/ScriptGeneratorA.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/component/ScriptGeneratorA.java
@@ -1,0 +1,10 @@
+package eu.europa.ted.eforms.sdk.component;
+
+@SdkComponent(versions = "1", componentType = SdkComponentType.SCRIPT_GENERATOR)
+class ScriptGeneratorA implements TestComponent {
+
+  @Override
+  public String testMethod() {
+    return "A";
+  }
+}

--- a/src/test/java/eu/europa/ted/eforms/sdk/component/ScriptGeneratorB.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/component/ScriptGeneratorB.java
@@ -1,0 +1,10 @@
+package eu.europa.ted.eforms.sdk.component;
+
+@SdkComponent(versions = "1", componentType = SdkComponentType.SCRIPT_GENERATOR)
+class ScriptGeneratorB implements TestComponent {
+
+  @Override
+  public String testMethod() {
+    return "B";
+  }
+}

--- a/src/test/java/eu/europa/ted/eforms/sdk/component/ScriptGeneratorB.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/component/ScriptGeneratorB.java
@@ -1,6 +1,6 @@
 package eu.europa.ted.eforms.sdk.component;
 
-@SdkComponent(versions = "1", componentType = SdkComponentType.SCRIPT_GENERATOR)
+@SdkComponent(versions = "1", componentType = SdkComponentType.SCRIPT_GENERATOR, qualifier = "B")
 class ScriptGeneratorB implements TestComponent {
 
   @Override

--- a/src/test/java/eu/europa/ted/eforms/sdk/component/ScriptGeneratorSubclass.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/component/ScriptGeneratorSubclass.java
@@ -1,5 +1,6 @@
 package eu.europa.ted.eforms.sdk.component;
 
+@SdkComponent(versions = "1", componentType = SdkComponentType.SCRIPT_GENERATOR, qualifier = "other")
 class ScriptGeneratorSubclass extends ScriptGeneratorA {
 
   @Override

--- a/src/test/java/eu/europa/ted/eforms/sdk/component/ScriptGeneratorSubclass.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/component/ScriptGeneratorSubclass.java
@@ -1,0 +1,9 @@
+package eu.europa.ted.eforms.sdk.component;
+
+class ScriptGeneratorSubclass extends ScriptGeneratorA {
+
+  @Override
+  public String testMethod() {
+    return "Subclass";
+  }
+}

--- a/src/test/java/eu/europa/ted/eforms/sdk/component/SdkComponentFactoryTest.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/component/SdkComponentFactoryTest.java
@@ -1,6 +1,8 @@
 package eu.europa.ted.eforms.sdk.component;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.junit.jupiter.api.Test;
 
 class SdkComponentFactoryTest {
@@ -16,12 +18,44 @@ class SdkComponentFactoryTest {
   @Test
   void testMultipleComponentImpl() throws InstantiationException {
     MyComponentFactory factory = new MyComponentFactory();
-    TestComponent impl =
+
+    TestComponent implNoQualifier =
         factory.getComponentImpl("1.0", SdkComponentType.SCRIPT_GENERATOR, TestComponent.class);
 
-    // impl could be either ScriptGeneratorA, ScriptGeneratorB, or ScriptGeneratorSubclass
-    // depending on which was the last found in SdkComponentFactory.populateComponents()
-    assertEquals(ScriptGeneratorSubclass.class, impl.getClass());
-    assertEquals("Subclass", impl.testMethod());
+    // No qualifier specified, so we get an instance of ScriptGeneratorA
+    assertEquals(ScriptGeneratorA.class, implNoQualifier.getClass());
+    assertEquals("A", implNoQualifier.testMethod());
+
+    TestComponent implQualifierOther =
+        factory.getComponentImpl("1.0", SdkComponentType.SCRIPT_GENERATOR, "other", TestComponent.class);
+
+    // Qualifier is "other", so we get an instance of ScriptGeneratorSubclass
+    assertEquals(ScriptGeneratorSubclass.class, implQualifierOther.getClass());
+    assertEquals("Subclass", implQualifierOther.testMethod());
+  }
+
+  @Test
+  void testComponentNotFound() throws InstantiationException {
+    MyComponentFactory factory = new MyComponentFactory();
+
+    // No component for this version
+    assertThrows(IllegalArgumentException.class, () ->
+        factory.getComponentImpl("2.0", SdkComponentType.SCRIPT_GENERATOR, TestComponent.class));
+
+    // No component for this type
+    assertThrows(IllegalArgumentException.class, () ->
+        factory.getComponentImpl("1.0", SdkComponentType.CODELIST, TestComponent.class));
+
+    // No component for this qualifier
+    assertThrows(IllegalArgumentException.class, () ->
+        factory.getComponentImpl("1.0", SdkComponentType.SCRIPT_GENERATOR, "BAD", TestComponent.class));
+
+    // Only component for this version and type does not have a qualifier
+    assertThrows(IllegalArgumentException.class, () ->
+    factory.getComponentImpl("0.5", SdkComponentType.EFX_EXPRESSION_TRANSLATOR, "BAD", TestComponent.class));
+
+    // Only component for this version and type has a qualifier
+    assertThrows(IllegalArgumentException.class, () ->
+    factory.getComponentImpl("1.0", SdkComponentType.NODE, TestComponent.class));
   }
 }

--- a/src/test/java/eu/europa/ted/eforms/sdk/component/SdkComponentFactoryTest.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/component/SdkComponentFactoryTest.java
@@ -3,24 +3,13 @@ package eu.europa.ted.eforms.sdk.component;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
-@SdkComponent(versions = "0.5", componentType = SdkComponentType.EFX_EXPRESSION_TRANSLATOR)
-class SdkComponentFactoryTest extends SdkComponentFactory implements TestComponent {
-
-  @Override
-  protected <T> T getComponentImpl(String sdkVersion, SdkComponentType componentType, Class<T> intf,
-      Object... initArgs) throws InstantiationException {
-    return super.getComponentImpl(sdkVersion, componentType, intf, initArgs);
-  }
-
-  @Override
-  public String testMethod() {
-    return null;
-  }
+class SdkComponentFactoryTest {
 
   @Test
   void testGetComponentImpl() throws InstantiationException {
-    Object impl =
-        getComponentImpl("0.5", SdkComponentType.EFX_EXPRESSION_TRANSLATOR, TestComponent.class);
-    assertEquals(getClass(), impl.getClass());
+    MyComponentFactory factory = new MyComponentFactory();
+    TestComponent impl =
+        factory.getComponentImpl("0.5", SdkComponentType.EFX_EXPRESSION_TRANSLATOR, TestComponent.class);
+    assertEquals(MyComponent.class, impl.getClass());
   }
 }

--- a/src/test/java/eu/europa/ted/eforms/sdk/component/SdkComponentFactoryTest.java
+++ b/src/test/java/eu/europa/ted/eforms/sdk/component/SdkComponentFactoryTest.java
@@ -12,4 +12,16 @@ class SdkComponentFactoryTest {
         factory.getComponentImpl("0.5", SdkComponentType.EFX_EXPRESSION_TRANSLATOR, TestComponent.class);
     assertEquals(MyComponent.class, impl.getClass());
   }
+
+  @Test
+  void testMultipleComponentImpl() throws InstantiationException {
+    MyComponentFactory factory = new MyComponentFactory();
+    TestComponent impl =
+        factory.getComponentImpl("1.0", SdkComponentType.SCRIPT_GENERATOR, TestComponent.class);
+
+    // impl could be either ScriptGeneratorA, ScriptGeneratorB, or ScriptGeneratorSubclass
+    // depending on which was the last found in SdkComponentFactory.populateComponents()
+    assertEquals(ScriptGeneratorSubclass.class, impl.getClass());
+    assertEquals("Subclass", impl.testMethod());
+  }
 }


### PR DESCRIPTION
This qualifier enables having several components implementations for the
same SDK version and with the same component type. You can choose the
one you want by indicating its qualifier when calling getComponentImpl().

The qualifier defaults to the empty string, so this is backwards
compatible for existing code. The behaviour will be the same if you don't
have components with the same version and type. but if you do an
exception will be thrown instead of returning arbitrarily one of the
component implementation.