### PR TITLE
Fix XPathProcessor context predicate handling and update release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-# eForms Core Library 1.4.0 Release Notes
+# eForms Core Library 1.5.0 Release Notes
 
 The eForms Core Library is a collection of utilities that are used by our sample applications as well as the EFX Toolkit for Java Developers.
 
 ## In this release
 
-This release adds the option to indicate a qualifier for SDK components. If there are 2 or more classes that have an @SdkComponent annotation with the same version and component type, this allows you to differentiate them and load the component with the matching qualifier.
+This release fixes an issue in the XPathProcessor that could cause a redundant predicate production when contextualising XPaths with multiple predicates.
 
 The versions of various dependencies was updated: ANTLR 4.13.1, JAXB 4.0.4, logback 1.5.3, ph-genericode 7.1.1.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The eForms Core Library is a collection of utilities that are used by our sample
 
 This release fixes an issue in the XPathProcessor that could cause a redundant predicate production when contextualising XPaths with multiple predicates.
 
-The versions of various dependencies was updated: ANTLR 4.13.1, JAXB 4.0.4, logback 1.5.3, ph-genericode 7.1.1.
+The versions of various dependencies was updated: Apache Commons IO 2.19.0, Apache Commons Lang 3.18.0, Jackson 2.18.3, logback 1.5.18.
 
 ## Download
 

--- a/src/main/java/eu/europa/ted/eforms/xpath/XPathProcessor.java
+++ b/src/main/java/eu/europa/ted/eforms/xpath/XPathProcessor.java
@@ -76,17 +76,20 @@ public class XPathProcessor {
       // we want to use a dot step with the predicate of the path.
       if (!contextQueue.isEmpty() && !pathQueue.isEmpty()
           && pathQueue.peek().isSameAsOrNarrowerThan(contextQueue.peek())) {
-        contextQueue.poll();  // consume the same step from the contextQueue
+        // Consume the same step from the contextQueue and get its predicates
+        List<String> contextPredicates = contextQueue.poll().getPredicates(); 
+        // Keep only the predicates that are not in the context.
+        String pathPredicates = pathQueue.poll().getPredicates().stream().filter(p -> !contextPredicates.contains(p)).collect(Collectors.joining(""));
         if (contextQueue.isEmpty()) {
           // Since there are no more steps in the contextQueue, the relative xpath should 
           // start with a dot step to provide a context for the predicate.
-          relativeXpath += "." + pathQueue.poll().getPredicateText();
+          relativeXpath += "." + pathPredicates;
         } else {
           // Since there are more steps in the contextQueue which we will need to navigate back to,
-          // using back-steps, we will use a back-step to provide context of the predicate.
+          // using back-steps, we will use a back-step to provide context for the predicate.
           // This avoids an output that looks like ../.[predicate] which is valid but silly.  
           contextQueue.poll();  // consume the step from the contextQueue
-          relativeXpath += ".." + pathQueue.poll().getPredicateText();
+          relativeXpath += ".." + pathPredicates;
         }
       }
 

--- a/src/test/java/eu/europa/ted/eforms/xpath/XPathProcessorTest.java
+++ b/src/test/java/eu/europa/ted/eforms/xpath/XPathProcessorTest.java
@@ -65,7 +65,7 @@ class XPathProcessorTest {
 
   @Test
   void testIdentical_WithPredicates() {
-    assertEquals(".[d = e][f = g]", contextualize("/a/b/c[d = e]", "/a/b/c[d = e][f = g]"));
+    assertEquals(".[f = g]", contextualize("/a/b/c[d = e]", "/a/b/c[d = e][f = g]"));
   }
 
   @Test
@@ -181,7 +181,7 @@ class XPathProcessorTest {
 
   @Test
   void testPredicateMoreInXpath() {
-    assertEquals("..[e][f]/c/d", contextualize("/a/b[e]/c", "/a/b[e][f]/c/d"));
+    assertEquals("..[f]/c/d", contextualize("/a/b[e]/c", "/a/b[e][f]/c/d"));
   }
 
   @Test


### PR DESCRIPTION
Update the XPathProcessor to correctly handle context predicates, addressing an issue that caused redundant predicate production. Release notes reflect the changes made in version 1.5.0 of the eForms Core Library.