### PR TITLE
perf: Replace Reflections with ClassGraph and share scan across factories (TEDEFO-5033)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <version.maven>3.8.6</version.maven>
     <version.ph-jaxb>11.1.3</version.ph-jaxb>
     <version.ph-genericode>7.1.1</version.ph-genericode>
-    <version.reflections>0.10.2</version.reflections>
+    <version.classgraph>4.8.179</version.classgraph>
     <version.resolver>1.8.2</version.resolver>
     <version.semver4j>3.1.0</version.semver4j>
     <version.slf4j>2.0.3</version.slf4j>
@@ -76,9 +76,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.reflections</groupId>
-        <artifactId>reflections</artifactId>
-        <version>${version.reflections}</version>
+        <groupId>io.github.classgraph</groupId>
+        <artifactId>classgraph</artifactId>
+        <version>${version.classgraph}</version>
       </dependency>
 
       <dependency>
@@ -228,8 +228,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.reflections</groupId>
-      <artifactId>reflections</artifactId>
+      <groupId>io.github.classgraph</groupId>
+      <artifactId>classgraph</artifactId>
     </dependency>
 
     <!-- Apache Commons -->

--- a/src/main/java/eu/europa/ted/eforms/sdk/component/SdkComponentFactory.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/component/SdkComponentFactory.java
@@ -9,11 +9,9 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Stream;
 import eu.europa.ted.eforms.sdk.SdkVersion;
-import org.reflections.Reflections;
-import org.reflections.util.ClasspathHelper;
-import org.reflections.util.ConfigurationBuilder;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ScanResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +20,26 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class SdkComponentFactory {
   private static final Logger logger = LoggerFactory.getLogger(SdkComponentFactory.class);
+
+  /**
+   * Lazy-init holder for the JVM-wide classpath scan. Triggered the first time any
+   * {@link SdkComponentFactory} subclass is constructed; the resulting list is shared
+   * by all subclasses so that the (potentially expensive) classpath walk runs only once
+   * per JVM rather than once per factory subclass.
+   */
+  private static final class AnnotatedClassesHolder {
+    static final List<Class<?>> CLASSES = scan();
+
+    private static List<Class<?>> scan() {
+      logger.debug("Scanning the classpath for types annotated with {}", SdkComponent.class);
+      try (ScanResult result = new ClassGraph()
+          .enableAnnotationInfo()
+          .ignoreClassVisibility()
+          .scan()) {
+        return result.getClassesWithAnnotation(SdkComponent.class).loadClasses();
+      }
+    }
+  }
 
   private Map<String, Map<ComponentSelector, SdkComponentDescriptor<?>>> componentsMap;
 
@@ -65,67 +83,47 @@ public abstract class SdkComponentFactory {
   private void populateComponents() {
     Class<SdkComponent> annotationType = SdkComponent.class;
 
-    logger.debug("Looking in the classpath for types annotated with {}", annotationType);
-
     if (componentsMap == null) {
       componentsMap = new HashMap<>();
     }
 
-    // Get a list of all the packages loaded by the available classloaders.
-    // This can be a bit expensive in some situations, so this method factory should
-    // be ensured to run as less as possible (ideally only once).
-    String[] availablePackages = Arrays
-        .stream(ClasspathHelper.classLoaders())
-        .map(ClassLoader::getDefinedPackages)
-        .flatMap(Stream::of)
-        .map(Package::getName)
-        .toArray(String[]::new);
+    AnnotatedClassesHolder.CLASSES.forEach((Class<?> clazz) -> {
+      logger.trace("Processing type [{}]", clazz);
 
-    if (logger.isTraceEnabled()) {
-      final List<String> packages = Arrays.asList(availablePackages);
-      packages.stream().sorted()
-          .forEach(p -> logger.trace(p));
-    }
+      SdkComponent annotation = clazz.getAnnotation(annotationType);
 
-    new Reflections(ConfigurationBuilder.build().forPackages(availablePackages))
-        .getTypesAnnotatedWith(annotationType).stream()
-        .forEach((Class<?> clazz) -> {
-          logger.trace("Processing type [{}]", clazz);
+      String[] supportedSdkVersions = annotation.versions();
+      SdkComponentType componentType = annotation.componentType();
+      String qualifier = annotation.qualifier();
+      ComponentSelector selector = new ComponentSelector(componentType, qualifier);
 
-          SdkComponent annotation = clazz.getAnnotation(annotationType);
+      logger.trace("Class [{}] has a component type of [{}] and supports SDK versions [{}]",
+          clazz, componentType, supportedSdkVersions);
 
-          String[] supportedSdkVersions = annotation.versions();
-          SdkComponentType componentType = annotation.componentType();
-          String qualifier = annotation.qualifier();
-          ComponentSelector selector = new ComponentSelector(componentType, qualifier);
+      Arrays.asList(supportedSdkVersions).forEach((String sdkVersion) -> {
+        SdkComponentDescriptor<?> component =
+            new SdkComponentDescriptor<>(sdkVersion, componentType, clazz);
 
-          logger.trace("Class [{}] has a component type of [{}] and supports SDK versions [{}]",
-              clazz, componentType, supportedSdkVersions);
+        Map<ComponentSelector, SdkComponentDescriptor<?>> components =
+            componentsMap.get(sdkVersion);
 
-          Arrays.asList(supportedSdkVersions).forEach((String sdkVersion) -> {
-            SdkComponentDescriptor<?> component =
-                new SdkComponentDescriptor<>(sdkVersion, componentType, clazz);
+        if (components != null) {
+          SdkComponentDescriptor<?> existingComponent = components.get(selector);
 
-            Map<ComponentSelector, SdkComponentDescriptor<?>> components =
-                componentsMap.get(sdkVersion);
+          if (existingComponent != null && !existingComponent.equals(component)) {
+            throw new IllegalArgumentException(MessageFormat.format(
+                "More than one components of type [{0}] have been found for SDK version [{1}]:\n\t- {2}\n\t- {3}",
+                componentType, sdkVersion, existingComponent.getImplType().getName(),
+                clazz.getName()));
+          }
+        } else {
+          components = new HashMap<>();
+          componentsMap.put(sdkVersion, components);
+        }
 
-            if (components != null) {
-              SdkComponentDescriptor<?> existingComponent = components.get(selector);
-
-              if (existingComponent != null && !existingComponent.equals(component)) {
-                throw new IllegalArgumentException(MessageFormat.format(
-                    "More than one components of type [{0}] have been found for SDK version [{1}]:\n\t- {2}\n\t- {3}",
-                    componentType, sdkVersion, existingComponent.getImplType().getName(),
-                    clazz.getName()));
-              }
-            } else {
-              components = new HashMap<>();
-              componentsMap.put(sdkVersion, components);
-            }
-
-            components.put(selector, component);
-          });
-        });
+        components.put(selector, component);
+      });
+    });
   }
 
   protected <T> T getComponentImpl(String sdkVersion, final SdkComponentType componentType,


### PR DESCRIPTION
## Summary

Eliminates the slow `Reflections` classpath scan that made the EFX validator (and any other consumer of `SdkComponentFactory`) prohibitively slow when run from a Spring Boot fat JAR (`mdm-cli`, `mdm-war`).

Two changes in [SdkComponentFactory](src/main/java/eu/europa/ted/eforms/sdk/component/SdkComponentFactory.java):

1. **Reflections → ClassGraph.** Modern, actively maintained, native support for Spring Boot fat JARs, ASM-based bytecode reading. `.ignoreClassVisibility()` preserves the previous behaviour of finding non-public `@SdkComponent` classes.
2. **Cross-factory scan dedup.** Hoist the scan to a static `AnnotatedClassesHolder` whose result is shared across all `SdkComponentFactory` subclasses (today: `SdkEntityFactory`, `ComponentFactory`, `EfxTranslatorFactory`). Three independent scans → one.

## Measured impact (mdm-cli `analyse-sdk --efx` against eForms-SDK)

| | Before | After |
|---|---|---|
| Number of scans per JVM | 3 | 1 |
| Total classpath scan time | 43 s (3 × ~14 s) | **2.8 s** |
| Per-scan duration | 13–15 s | 2.8 s |

Public API unchanged. Subclass constructors are unaffected.

## Side effect: TEDEFO-3328

The `Reflections` configuration relied on `ClassLoader.getDefinedPackages()`, which only returns packages whose classes have already been initialised — the root cause of TEDEFO-3328 (components in a not-yet-touched JAR being missed). ClassGraph scans by classpath URL, so this trap is gone. We can likely close TEDEFO-3328 alongside this change.

## What is NOT addressed

The remaining `analyse-sdk --efx` runtime (~9 minutes for SDK 2.0) is dominated by per-template translation work inside `EfxTemplateTranslator.renderTemplate()`, not by classpath scanning. That is a separate optimisation problem in `efx-toolkit-java` and is being investigated separately.

## Test plan

- [x] All 67 `eforms-core-java` tests pass
- [x] All 1335 `efx-toolkit-java` tests pass against the new `eforms-core-java` SNAPSHOT
- [x] All 161 `eforms-sdk-analyzer` tests pass against the chain
- [x] `mdm-cli analyse-sdk --efx` against eForms-SDK 2.0 source: same 158 errors found before and after the change (correctness preserved)