### PR TITLE
TEDEFO-4860 adding validation folder and rules.efx in enum

### DIFF
--- a/src/main/java/eu/europa/ted/eforms/sdk/SdkConstants.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/SdkConstants.java
@@ -19,50 +19,76 @@ public class SdkConstants {
   public static final String SDK_GROUP_ID = "eu.europa.ted.eforms";
   public static final String SDK_ARTIFACT_ID = "eforms-sdk";
   public static final String SDK_PACKAGING = "jar";
+  
+  /**
+   * Forward folder of SDK2+, it can exist in some folders.
+   */
+  public static final String FWD = "fwd"; 
 
   private SdkConstants() {}
 
   public enum SdkResource implements PathResource {
-    CODELISTS(Path.of("codelists")), //
-    CODELISTS_JSON(Path.of("codelists", "codelists.json")), //
+    CODELISTS(Path.of("codelists")),
+    CODELISTS_JSON(Path.of("codelists", "codelists.json")),
 
-    EFX_GRAMMAR(Path.of("efx-grammar")), //
+    EFX_GRAMMAR(Path.of("efx-grammar")),
 
-    FIELDS(Path.of("fields")), //
-    FIELDS_JSON(Path.of("fields", "fields.json")), //
-
-    NOTICE_TYPES(Path.of("notice-types")), //
-    NOTICE_TYPES_JSON(Path.of("notice-types", "notice-types.json")), //
+    FIELDS(Path.of("fields")),
+    FIELDS_JSON(Path.of("fields", "fields.json")),
+    
+    // FIELDS FWD FOLDER.
+    BUSINESS_ENTITIES_COMPOSITION(Path.of("fields", FWD, "business-entities-composition.json")),
+    BUSINESS_ENTITIES_HIERARCHY(Path.of("fields", FWD, "business-entities-hierarchies.json")),
+    BUSINESS_ENTITIES_PROPERTIES(Path.of("fields", FWD, "business-entities-properties.json")),
+    BUSINESS_TERMS(Path.of("fields", FWD, "business-terms.json")),
+    DATA_TYPES(Path.of("fields", FWD, "data-types.json")),
+    FIELDS_JSON_LIST(Path.of("fields", FWD, "fields.json")),
+    NODES_JSON_LIST(Path.of("fields", FWD, "nodes.json")),
 
     /**
-     * XSD files.
+     * Related to asset migration.
      */
-    SCHEMAS(Path.of("schemas")), //
-    SCHEMAS_COMMON(Path.of("schemas", "common")), //
-    SCHEMAS_MAINDOC(Path.of("schemas", "maindoc")), //
+    MIGRATION(Path.of("migration")),
+    MIGRATION_JSON(Path.of("migration", "migration.json")),
 
-    SCHEMATRONS(Path.of("schematrons")), //
-    SCHEMATRONS_DYNAMIC(Path.of("schematrons", "dynamic")), //
-    SCHEMATRONS_STATIC(Path.of("schematrons", "static")), //
+    NOTICE_TYPES(Path.of("notice-types")),
+    NOTICE_TYPES_JSON(Path.of("notice-types", "notice-types.json")),
+
+    /**
+     * Schema files.
+     */
+    SCHEMAS(Path.of("schemas")),
+    SCHEMAS_JSON(Path.of("schemas", "schemas.json")),
+
+    SCHEMAS_COMMON(Path.of("schemas", "common")),
+    SCHEMAS_MAINDOC(Path.of("schemas", "maindoc")),
+
+    SCHEMATRONS(Path.of("schematrons")),
+    SCHEMATRONS_DYNAMIC(Path.of("schematrons", "dynamic")),
+    SCHEMATRONS_STATIC(Path.of("schematrons", "static")),
 
     /**
      * Internal usage, tedweb.
      */
-    TED(Path.of(".ted")), //
-    TED_TEDWEB(Path.of(".ted", "tedweb")), //
-    TED_TEDWEB_REPORT_METADATA(Path.of(".ted", "tedweb", "report-metadata.json")), //
-    TED_TEDWEB_SEARCH_METADATA(Path.of(".ted", "tedweb", "search-metadata.json")), //
+    TED(Path.of(".ted")),
+    TED_TEDWEB(Path.of(".ted", "tedweb")),
+    TED_TEDWEB_REPORT_METADATA(Path.of(".ted", "tedweb", "report-metadata.json")),
+    TED_TEDWEB_SEARCH_METADATA(Path.of(".ted", "tedweb", "search-metadata.json")),
 
     /**
      * Internationalisation, labels.
      */
-    TRANSLATIONS(Path.of("translations")), //
+    TRANSLATIONS(Path.of("translations")),
+    
     /**
      * The index file for translations, only present in SDK 1.10.0 and later.
      */
-    TRANSLATIONS_JSON(Path.of("translations", "translations.json")), //
+    TRANSLATIONS_JSON(Path.of("translations", "translations.json")),
 
-    VIEW_TEMPLATES(Path.of("view-templates")), //
+    VALIDATION(Path.of("validation")),
+    VALIDATION_RULES_EFX(Path.of("validation", "rules.efx")),
+
+    VIEW_TEMPLATES(Path.of("view-templates")),
     VIEW_TEMPLATES_JSON(Path.of("view-templates", "view-templates.json"));
 
     private Path path;


### PR DESCRIPTION
also adding fwd folder and other new files.
This enum is used in the MDM and can be used in esender applications.
They are useful to avoid duplication or to lookup references.