### PR TITLE
TEDEFO-4860 adding more constants and enum entries in SdkConstants

### DIFF
--- a/src/main/java/eu/europa/ted/eforms/sdk/SdkConstants.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/SdkConstants.java
@@ -4,9 +4,29 @@ import java.nio.file.Path;
 import eu.europa.ted.eforms.sdk.resource.PathResource;
 
 public class SdkConstants {
+  
+  public static final Path DEFAULT_SDK_ROOT = Path.of("eforms-sdk");
+  
+  public static final String CODELISTS_DIR_NAME = "codelists";
+  public static final String CODELISTS_JSON_FILE_NAME = "codelists.json";
+
   public static final String FIELDS_JSON_XML_STRUCTURE_KEY = "xmlStructure";
   public static final String FIELDS_JSON_FIELDS_KEY = "fields";
+  public static final String FIELDS_DIR_NAME = "fields";
 
+  public static final String NODES_JSON = "nodes.json";
+  public static final String FIELDS_JSON_FILENAME = "fields.json";
+  public static final String DATA_TYPES_JSON = "data-types.json";
+  public static final String BUSINESS_TERMS_JSON = "business-terms.json";
+  public static final String BUSINESS_ENTITIES_PROPERTIES_JSON = "business-entities-properties.json";
+  public static final String BUSINESS_ENTITIES_HIERARCHIES_JSON = "business-entities-hierarchies.json";
+  public static final String BUSINESS_ENTITIES_COMPOSITION_JSON = "business-entities-composition.json";
+
+  public static final String MIGRATION_DIR_NAME = "migration";
+  public static final String MIGRATION_JSON_FILE_NAME = "migration.json";
+
+  public static final String NOTICE_TYPES_DIR_NAME = "notice-types";
+  public static final String NOTICE_TYPES_JSON_FILE_NAME = "notice-types.json";
   public static final String NOTICE_TYPES_JSON_SUBTYPES_KEY = "noticeSubTypes";
   public static final String NOTICE_TYPES_JSON_DOCUMENT_TYPES_KEY = "documentTypes";
   public static final String NOTICE_TYPES_JSON_DOCUMENT_TYPE_KEY = "documentType";
@@ -14,58 +34,84 @@ public class SdkConstants {
   public static final String NOTICE_TYPES_JSON_ROOT_ELEMENT_KEY = "rootElement";
   public static final String NOTICE_CUSTOMIZATION_ID_VERSION_PREFIX = "eforms-sdk-";
 
-  public static final Path DEFAULT_SDK_ROOT = Path.of("eforms-sdk");
-
   public static final String SDK_GROUP_ID = "eu.europa.ted.eforms";
   public static final String SDK_ARTIFACT_ID = "eforms-sdk";
   public static final String SDK_PACKAGING = "jar";
   
+  public static final String SCHEMAS_DIR_NAME = "schemas";
+  public static final String SCHEMAS_JSON_FILE_NAME = "schemas.json";
+  public static final String SCHEMATRONS_DIR_NAME = "schematrons";
+  
+  public static final String TRANSLATIONS_DIR_NAME = "translations";
+  public static final String TRANSLATIONS_JSON_FILE_NAME = "translations.json";
+  public static final String VALIDATION_DIR_NAME = "validation";
+  public static final String VALIDATION_RULES_EFX_FILE_NAME = "rules.efx";
+  public static final String VALIDATION_DEPENDENCIES_JSON_FILE_NAME = "dependencies.json";
+
+  public static final String VIEW_TEMPLATES_DIR_NAME = "view-templates";
+  public static final String VIEW_TEMPLATES_JSON_FILE_NAME = "view-templates.json";
+
   /**
-   * Forward folder of SDK2+, it can exist in some folders.
+   * Forward folder of SDK2+, it can exist in some folders. 
+   * Files in that folder can be used to preview SDK2 features.
    */
   public static final String FWD = "fwd"; 
 
   private SdkConstants() {}
 
   public enum SdkResource implements PathResource {
-    CODELISTS(Path.of("codelists")),
-    CODELISTS_JSON(Path.of("codelists", "codelists.json")),
+    CODELISTS(Path.of(CODELISTS_DIR_NAME)),
+    CODELISTS_JSON(Path.of(CODELISTS_DIR_NAME, CODELISTS_JSON_FILE_NAME)),
 
     EFX_GRAMMAR(Path.of("efx-grammar")),
 
-    FIELDS(Path.of("fields")),
-    FIELDS_JSON(Path.of("fields", "fields.json")),
+    FIELDS(Path.of(FIELDS_DIR_NAME)),
     
-    // FIELDS FWD FOLDER.
-    BUSINESS_ENTITIES_COMPOSITION(Path.of("fields", FWD, "business-entities-composition.json")),
-    BUSINESS_ENTITIES_HIERARCHY(Path.of("fields", FWD, "business-entities-hierarchies.json")),
-    BUSINESS_ENTITIES_PROPERTIES(Path.of("fields", FWD, "business-entities-properties.json")),
-    BUSINESS_TERMS(Path.of("fields", FWD, "business-terms.json")),
-    DATA_TYPES(Path.of("fields", FWD, "data-types.json")),
-    FIELDS_JSON_LIST(Path.of("fields", FWD, "fields.json")),
-    NODES_JSON_LIST(Path.of("fields", FWD, "nodes.json")),
+    /**
+     * Fields and nodes.
+     */
+    FIELDS_JSON(Path.of(FIELDS_DIR_NAME, FIELDS_JSON_FILENAME)),
+    
+    BUSINESS_ENTITIES_COMPOSITION(Path.of(FIELDS_DIR_NAME, FWD, BUSINESS_ENTITIES_COMPOSITION_JSON)),
+    BUSINESS_ENTITIES_HIERARCHY(Path.of(FIELDS_DIR_NAME, FWD, BUSINESS_ENTITIES_HIERARCHIES_JSON)),
+    BUSINESS_ENTITIES_PROPERTIES(Path.of(FIELDS_DIR_NAME, FWD, BUSINESS_ENTITIES_PROPERTIES_JSON)),
+    BUSINESS_TERMS(Path.of(FIELDS_DIR_NAME, FWD, BUSINESS_TERMS_JSON)),
+    DATA_TYPES(Path.of(FIELDS_DIR_NAME, FWD, DATA_TYPES_JSON)),
+    
+    /**
+     * JSON with array of fields.
+     */
+    FIELDS_JSON_LIST(Path.of(FIELDS_DIR_NAME, FWD, FIELDS_JSON_FILENAME)),
+    
+    /**
+     * JSON with array of nodes.
+     */
+    NODES_JSON_LIST(Path.of(FIELDS_DIR_NAME, FWD, NODES_JSON)),
 
     /**
      * Related to asset migration.
      */
-    MIGRATION(Path.of("migration")),
-    MIGRATION_JSON(Path.of("migration", "migration.json")),
+    MIGRATION(Path.of(MIGRATION_DIR_NAME)),
+    MIGRATION_JSON(Path.of(MIGRATION_DIR_NAME, MIGRATION_JSON_FILE_NAME)),
 
-    NOTICE_TYPES(Path.of("notice-types")),
-    NOTICE_TYPES_JSON(Path.of("notice-types", "notice-types.json")),
+    /**
+     * Notice Types Definitions (NTD).
+     */
+    NOTICE_TYPES(Path.of(NOTICE_TYPES_DIR_NAME)),
+    NOTICE_TYPES_JSON(Path.of(NOTICE_TYPES_DIR_NAME, NOTICE_TYPES_JSON_FILE_NAME)),
 
     /**
      * Schema files.
      */
-    SCHEMAS(Path.of("schemas")),
-    SCHEMAS_JSON(Path.of("schemas", "schemas.json")),
+    SCHEMAS(Path.of(SCHEMAS_DIR_NAME)),
+    SCHEMAS_JSON(Path.of(SCHEMAS_DIR_NAME, SCHEMAS_JSON_FILE_NAME)),
 
-    SCHEMAS_COMMON(Path.of("schemas", "common")),
-    SCHEMAS_MAINDOC(Path.of("schemas", "maindoc")),
+    SCHEMAS_COMMON(Path.of(SCHEMAS_DIR_NAME, "common")),
+    SCHEMAS_MAINDOC(Path.of(SCHEMAS_DIR_NAME, "maindoc")),
 
-    SCHEMATRONS(Path.of("schematrons")),
-    SCHEMATRONS_DYNAMIC(Path.of("schematrons", "dynamic")),
-    SCHEMATRONS_STATIC(Path.of("schematrons", "static")),
+    SCHEMATRONS(Path.of(SCHEMATRONS_DIR_NAME)),
+    SCHEMATRONS_DYNAMIC(Path.of(SCHEMATRONS_DIR_NAME, "dynamic")),
+    SCHEMATRONS_STATIC(Path.of(SCHEMATRONS_DIR_NAME, "static")),
 
     /**
      * Internal usage, tedweb.
@@ -78,18 +124,19 @@ public class SdkConstants {
     /**
      * Internationalisation, labels.
      */
-    TRANSLATIONS(Path.of("translations")),
+    TRANSLATIONS(Path.of(TRANSLATIONS_DIR_NAME)),
     
     /**
      * The index file for translations, only present in SDK 1.10.0 and later.
      */
-    TRANSLATIONS_JSON(Path.of("translations", "translations.json")),
+    TRANSLATIONS_JSON(Path.of(TRANSLATIONS_DIR_NAME, TRANSLATIONS_JSON_FILE_NAME)),
 
-    VALIDATION(Path.of("validation")),
-    VALIDATION_RULES_EFX(Path.of("validation", "rules.efx")),
+    VALIDATION(Path.of(VALIDATION_DIR_NAME)),
+    VALIDATION_RULES_EFX(Path.of(VALIDATION_DIR_NAME, VALIDATION_RULES_EFX_FILE_NAME)),
+    VALIDATION_DEPENDENCIES_JSON(Path.of(VALIDATION_DIR_NAME, VALIDATION_DEPENDENCIES_JSON_FILE_NAME)),
 
-    VIEW_TEMPLATES(Path.of("view-templates")),
-    VIEW_TEMPLATES_JSON(Path.of("view-templates", "view-templates.json"));
+    VIEW_TEMPLATES(Path.of(VIEW_TEMPLATES_DIR_NAME)),
+    VIEW_TEMPLATES_JSON(Path.of(VIEW_TEMPLATES_DIR_NAME, VIEW_TEMPLATES_JSON_FILE_NAME));
 
     private Path path;
 


### PR DESCRIPTION
Adds named String constants for SDK folder/file names and refactors the SdkResource enum to use them instead of inline literals. Adds one new resource, VALIDATION_DEPENDENCIES_JSON (validation/dependencies.json), so the MDM's ValidationService can stop hardcoding that filename in a follow-up.

**Changes**

New resource: SdkResource.VALIDATION_DEPENDENCIES_JSON.
New *_DIR_NAME / *_FILE_NAME constants for existing resources.
Existing enum entries refactored to build paths from the constants (behavior-preserving).
Minor cleanup: relocated DEFAULT_SDK_ROOT, regrouped constants, comment tweaks.

**Impact**

No behavioral change: all existing SdkResource paths resolve to the same strings.
API only extended (one enum value + new constants); nothing renamed or removed.